### PR TITLE
Model publish fixes and post-training steps cleanup

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ author = 'Noronha Development Team'
 master_doc = 'index'
 
 # The full version, including alpha/beta/rc tags
-release = '1.6.0'
+release = '1.6.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/examples/2_lazy/lazy_predict.ipynb
+++ b/examples/2_lazy/lazy_predict.ipynb
@@ -33,7 +33,7 @@
     "import json\n",
     "import os\n",
     "import numpy as np\n",
-    "from sklearn.externals import joblib"
+    "import joblib"
    ]
   },
   {

--- a/noronha/common/constants.py
+++ b/noronha/common/constants.py
@@ -24,7 +24,7 @@ import re
 class FrameworkConst(object):
     
     FW_NAME = 'noronha-dataops'
-    FW_VERSION = '1.6.0'  # framework version
+    FW_VERSION = '1.6.1'  # framework version
     FW_TAG = 'latest'  # framework tag
 
 

--- a/noronha/tools/publish.py
+++ b/noronha/tools/publish.py
@@ -141,8 +141,9 @@ class Publisher(object):
             _replace=True
         )
 
-        self.train.reload()
-        self.train.update(mover=mv, ds=ds)
+        if self.train.name:
+            self.train.reload()
+            self.train.update(mover=mv, ds=ds)
 
         if get_purpose() == DockerConst.Section.IDE:
             LOG.info("For testing purposes, model files will be moved to the deployed model path")

--- a/noronha/tools/publish.py
+++ b/noronha/tools/publish.py
@@ -125,25 +125,35 @@ class Publisher(object):
                  uses_dataset: bool = True, dataset_name: str = None,
                  uses_pretrained: bool = False, pretrained_with: str = None,
                  lightweight: bool = False):
-        
+
+        version_name = version_name or self.train.name
         model_name = self._infer_parent_model(model_name)
         ds = self._infer_dataset(model_name, uses_dataset, dataset_name)
-
-        mv = self.mv_api.new(
-            name=version_name or self.train.name,
-            model=model_name,
-            ds=ds.name if ds else None,
-            train=self.train.name,
-            path=src_path,
-            details=details or {},
-            pretrained=self._infer_pretrained(uses_pretrained, pretrained_with),
-            lightweight=lightweight,
-            _replace=True
-        )
+        mv = None
+        err = None
+        
+        try:
+            mv = self.mv_api.new(
+                name=version_name,
+                model=model_name,
+                ds=ds.name if ds else None,
+                train=self.train.name,
+                path=src_path,
+                details=details or {},
+                pretrained=self._infer_pretrained(uses_pretrained, pretrained_with),
+                lightweight=lightweight,
+                _replace=True
+            )
+        except Exception as e:
+            LOG.warn("Model version {}:{} publish failed".format(model_name, version_name))
+            err = e
 
         if self.train.name:
             self.train.reload()
             self.train.update(mover=mv, ds=ds)
+
+        if err:
+            raise err
 
         if get_purpose() == DockerConst.Section.IDE:
             LOG.info("For testing purposes, model files will be moved to the deployed model path")

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ if os.environ.get('include_tests'):
 
 setup(
     name='noronha-dataops',
-    version='1.6.0',
+    version='1.6.1',
     url='https://github.com/noronha-dataops/noronha',
     author='Noronha Development Team',
     author_email='noronha.mlops@everis.com',


### PR DESCRIPTION
Model version publish behaves correctly when executing in IDE.

Training mongo document is correctly updated after model publish.

Fixed example for lazy prediction.

Moving Noronha to 1.6.1