### PR TITLE
Unfreeze mongoengine version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ author = 'Noronha Development Team'
 master_doc = 'index'
 
 # The full version, including alpha/beta/rc tags
-release = '1.6.2'
+release = '1.6.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/noronha/common/constants.py
+++ b/noronha/common/constants.py
@@ -24,7 +24,7 @@ import re
 class FrameworkConst(object):
     
     FW_NAME = 'noronha-dataops'
-    FW_VERSION = '1.6.2'  # framework version
+    FW_VERSION = '1.6.3'  # framework version
     FW_TAG = 'latest'  # framework tag
 
 

--- a/requirements/off_board_reqs.txt
+++ b/requirements/off_board_reqs.txt
@@ -4,7 +4,7 @@
 
 pyvalid==0.9.2
 kaptan
-mongoengine==0.18.2
+mongoengine
 artifactory
 nexus3-cli==1.0.2
 random_name

--- a/requirements/on_board_reqs.txt
+++ b/requirements/on_board_reqs.txt
@@ -4,7 +4,7 @@
 
 pyvalid==0.9.2
 kaptan
-mongoengine==0.18.2
+mongoengine
 artifactory
 nexus3-cli==1.0.2
 random_name

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ if os.environ.get('include_tests'):
 
 setup(
     name='noronha-dataops',
-    version='1.6.2',
+    version='1.6.3',
     url='https://github.com/noronha-dataops/noronha',
     author='Noronha Development Team',
     author_email='noronha.mlops@everis.com',


### PR DESCRIPTION
mongoengine was frozen a while ago because it had a blocking issue.

Now it has been resolved and Noronha install was failing due to conflict between mongoengine and setuptools.

Tests with current mongoengine version run without problems.